### PR TITLE
Fixed ZG vs-type weapons

### DIFF
--- a/js/data/gear_turtle.js
+++ b/js/data/gear_turtle.js
@@ -10602,7 +10602,8 @@ var gear = {
       "type": "Axe"
     },
     {
-      "name": "Gri'lek's Carver",
+      "name": "Gri'lek's Carver (vs Dragonkin)",
+      "ap": 117,
       "mindmg": 182,
       "maxdmg": 274,
       "speed": 3.9,
@@ -11047,7 +11048,8 @@ var gear = {
       "type": "Polearm"
     },
     {
-      "name": "Pitchfork of Madness",
+      "name": "Pitchfork of Madness (vs Demons)",
+      "ap": 117,
       "mindmg": 163,
       "maxdmg": 246,
       "speed": 3.5,
@@ -11386,7 +11388,17 @@ var gear = {
         "ppm": 3,
         "magic": true,
         "dmg": 90
-      }
+      },
+    {
+      "name": "Gri'lek's Grinder (vs Dragonkin)",
+      "ap": 48,
+      "mindmg": 75,
+      "maxdmg": 140,
+      "speed": 2.4,
+      "id": 19961,
+      "source": "ZG",
+      "phase": 4,
+      "type": "Mace"
     }
   ],
   "custom": [


### PR DESCRIPTION
Gri'lek's Carver and Pitchfork of Madness formatting fixed to include enemy type in their names, AP added

Gri'lek's Grinder added with the same format.

All follows precedent of Deathrune Leggings and AD trinket.